### PR TITLE
Stroke-Width as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The `progressStep()` method optionally takes an options object that you can use 
 * **font-family**: The font family used for the labels and numbers on each step.
 * **font-size**: The label font size. (Number size is set automatically based on the radius option.)
 * **font-weight**: The weight of the label and number fonts. 
+* **stroke-width**: The stroke width of the circles and the connectors. 
 
 For example, if you want to a `progressStep` instance with a yellow foreground color, you can set the `fillColor` option on creation:
 

--- a/progressStep.js
+++ b/progressStep.js
@@ -164,7 +164,7 @@
             circle.attr({
                 fill: _options.fillColor,
                 stroke: _options.strokeColor,
-                "stroke-width": 2
+                "stroke-width": _options["stroke-width"],
             });
             
             var highlight = _paper.circle(0, 0, _options.radius - 3);
@@ -269,6 +269,7 @@
                 this.connector = _paper.path("M" + hCenter + "," + vCenter + 
                                              "L" + (hCenter + usableWidth) + "," + vCenter);
                 this.connector.attr("stroke", _options.strokeColor);
+                this.connector.attr("stroke-width", _options["stroke-width"]);
                 this.connector.toBack();
                 
                 for (var stepCounter = 0; stepCounter < stepCount; stepCounter++) {
@@ -295,6 +296,7 @@
         labelOffset: 30,
         "font-family": "'Helvetica Neue', 'Helvetica', Arial, sans-serif",
         "font-size": 10,
-        "font-weight": "normal"
+        "font-weight": "normal",
+        "stroke-width": 2,
     };
 }(jQuery));


### PR DESCRIPTION
Adds the ability to set the stroke-width of the circles and the connectors from index.html without the designer having to go through the javascript file
Updates the README.md file with this new feature
